### PR TITLE
PR4: improve reliability with retries and noise suppression

### DIFF
--- a/cmd/codex-remote/retry.go
+++ b/cmd/codex-remote/retry.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func withRetry(maxAttempts int, fn func() error) error {
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+	var last error
+	for i := 1; i <= maxAttempts; i++ {
+		if err := fn(); err != nil {
+			last = err
+			if !isRetryableExecErr(err) || i == maxAttempts {
+				break
+			}
+			time.Sleep(time.Duration(1<<(i-1)) * 200 * time.Millisecond)
+			continue
+		}
+		return nil
+	}
+	if last == nil {
+		return nil
+	}
+	return fmt.Errorf("request failed after %d attempts: %w", maxAttempts, last)
+}


### PR DESCRIPTION
Implements PR-4 from the agreed plan.

- Adds shared retry wrapper for transient transport errors
- Treats file already closed and related channel errors as retryable
- Applies retries to watch/result/logs flows