### PR TITLE
PR5: support line/time-window log filtering

### DIFF
--- a/cmd/codex-remote/main.go
+++ b/cmd/codex-remote/main.go
@@ -53,7 +53,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "Usage:")
 	fmt.Fprintln(os.Stderr, "  codex-remote exec start --machine <name> --cmd <string> [--project <id> --ref <ref>] [--cwd <path>] [--env KEY=VAL ...]")
 	fmt.Fprintln(os.Stderr, "  codex-remote exec result --machine <name> --id <exec_id>")
-	fmt.Fprintln(os.Stderr, "  codex-remote exec logs --machine <name> --id <exec_id> [--stream stdout|stderr] [--tail 2000]")
+	fmt.Fprintln(os.Stderr, "  codex-remote exec logs --machine <name> --id <exec_id> [--stream stdout|stderr] [--tail 2000] [--tail-lines N] [--since RFC3339|10m] [--until RFC3339|10m]")
 	fmt.Fprintln(os.Stderr, "  codex-remote exec watch --machine <name> --id <exec_id> [--stream stdout|stderr|both] [--poll 1s]")
 	fmt.Fprintln(os.Stderr, "  codex-remote exec doctor --machine <name> [--json]")
 	fmt.Fprintln(os.Stderr, "  codex-remote exec cancel --machine <name> --id <exec_id>")
@@ -302,6 +302,9 @@ func execLogs(args []string) {
 	execID := fs.String("id", "", "exec id")
 	stream := fs.String("stream", "stdout", "stdout or stderr")
 	tailN := fs.Int64("tail", 2000, "tail bytes")
+	tailLines := fs.Int("tail-lines", 0, "tail lines")
+	since := fs.String("since", "", "lower time bound (RFC3339 or relative like 10m)")
+	until := fs.String("until", "", "upper time bound (RFC3339 or relative like 10m)")
 	if err := fs.Parse(args); err != nil {
 		os.Exit(2)
 	}
@@ -329,8 +332,26 @@ func execLogs(args []string) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+	sinceRFC3339, err := normalizeTimeBound(*since)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "--since:", err)
+		os.Exit(2)
+	}
+	untilRFC3339, err := normalizeTimeBound(*until)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "--until:", err)
+		os.Exit(2)
+	}
+	opts := client.ExecLogsOptions{
+		Stream:    *stream,
+		TailBytes: *tailN,
+		TailLines: *tailLines,
+		Since:     sinceRFC3339,
+		Until:     untilRFC3339,
+		Format:    "jsonl",
+	}
 	if err := withRetry(3, func() error {
-		return cl.ExecLogs(ctx, *execID, *stream, *tailN, "jsonl", os.Stdout)
+		return cl.ExecLogs(ctx, *execID, opts, os.Stdout)
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/codex-remote/main_test.go
+++ b/cmd/codex-remote/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"codex-runner/internal/codexremote/machcheck"
 )
@@ -72,5 +73,30 @@ func TestDeltaLines(t *testing.T) {
 	b, _ := json.Marshal(got)
 	if string(b) != `["d","e"]` {
 		t.Fatalf("deltaLines() = %s, want [\"d\",\"e\"]", b)
+	}
+}
+
+func TestNormalizeTimeBoundRFC3339(t *testing.T) {
+	in := "2026-01-01T00:00:00Z"
+	got, err := normalizeTimeBound(in)
+	if err != nil {
+		t.Fatalf("normalizeTimeBound() error = %v", err)
+	}
+	if got != in {
+		t.Fatalf("normalizeTimeBound() = %q, want %q", got, in)
+	}
+}
+
+func TestNormalizeTimeBoundDuration(t *testing.T) {
+	got, err := normalizeTimeBound("10m")
+	if err != nil {
+		t.Fatalf("normalizeTimeBound() error = %v", err)
+	}
+	ts, err := time.Parse(time.RFC3339Nano, got)
+	if err != nil {
+		t.Fatalf("parse output: %v", err)
+	}
+	if ts.After(time.Now().UTC()) {
+		t.Fatalf("expected past time, got %s", ts)
 	}
 }

--- a/cmd/codex-remote/timebound.go
+++ b/cmd/codex-remote/timebound.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+func normalizeTimeBound(v string) (string, error) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "", nil
+	}
+	if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
+		return t.UTC().Format(time.RFC3339Nano), nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return "", errors.New("must be RFC3339 or duration like 10m/2h")
+	}
+	return time.Now().UTC().Add(-d).Format(time.RFC3339Nano), nil
+}

--- a/cmd/codex-remote/watch.go
+++ b/cmd/codex-remote/watch.go
@@ -140,7 +140,11 @@ func fetchLogLines(cl *client.Client, execID string, stream string, tail int64) 
 		var buf bytes.Buffer
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
-		if err := cl.ExecLogs(ctx, execID, stream, tail, "jsonl", &buf); err != nil {
+		if err := cl.ExecLogs(ctx, execID, client.ExecLogsOptions{
+			Stream:    stream,
+			TailBytes: tail,
+			Format:    "jsonl",
+		}, &buf); err != nil {
 			return err
 		}
 		raw = append(raw[:0], buf.Bytes()...)

--- a/internal/codexd/service/service.go
+++ b/internal/codexd/service/service.go
@@ -264,16 +264,45 @@ func (s *Service) handleExecLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	tailStr := r.URL.Query().Get("tail")
+	tailLinesStr := r.URL.Query().Get("tail_lines")
 	var maxBytes int64 = 2000
+	var maxLines int
 	if tailStr != "" {
 		if n, err := strconv.ParseInt(tailStr, 10, 64); err == nil && n >= 0 {
 			maxBytes = n
 		}
 	}
+	if tailLinesStr != "" {
+		n, err := strconv.Atoi(tailLinesStr)
+		if err != nil || n < 0 {
+			writeErr(w, http.StatusBadRequest, "tail_lines must be >= 0")
+			return
+		}
+		maxLines = n
+	}
+	sinceFilter, err := parseRFC3339(r.URL.Query().Get("since"))
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "since must be RFC3339")
+		return
+	}
+	untilFilter, err := parseRFC3339(r.URL.Query().Get("until"))
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "until must be RFC3339")
+		return
+	}
 	format := r.URL.Query().Get("format") // "" or "jsonl"
 
 	path := filepath.Join(execDir, stream+".log")
-	b, err := tail.ReadTailBytes(path, maxBytes)
+	var b []byte
+	if maxLines > 0 {
+		b, err = tail.ReadTailLines(path, maxLines)
+	} else if tailStr != "" {
+		b, err = tail.ReadTailBytes(path, maxBytes)
+	} else if sinceFilter != nil || untilFilter != nil {
+		b, err = tail.ReadAll(path)
+	} else {
+		b, err = tail.ReadTailBytes(path, maxBytes)
+	}
 	if err != nil {
 		if os.IsNotExist(err) {
 			b = []byte{}
@@ -282,14 +311,15 @@ func (s *Service) handleExecLogs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	filtered := filterLogLinesByTime(bytes.Split(b, []byte{'\n'}), sinceFilter, untilFilter)
+	b = bytes.Join(filtered, []byte{'\n'})
 	if format != "jsonl" {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		_, _ = w.Write(b)
 		return
 	}
 	w.Header().Set("Content-Type", "application/x-ndjson; charset=utf-8")
-	lines := bytes.Split(b, []byte{'\n'})
-	for _, line := range lines {
+	for _, line := range filtered {
 		if len(line) == 0 {
 			continue
 		}
@@ -549,6 +579,65 @@ func readPID(execDir string) (int, error) {
 		return 0, err
 	}
 	return n, nil
+}
+
+func parseRFC3339(v string) (*time.Time, error) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return nil, nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, v)
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+func filterLogLinesByTime(lines [][]byte, since, until *time.Time) [][]byte {
+	if since == nil && until == nil {
+		return lines
+	}
+	out := make([][]byte, 0, len(lines))
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		ts, ok := extractLogTime(line)
+		if !ok {
+			out = append(out, line)
+			continue
+		}
+		if since != nil && ts.Before(*since) {
+			continue
+		}
+		if until != nil && ts.After(*until) {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+func extractLogTime(line []byte) (time.Time, bool) {
+	var obj map[string]any
+	if err := json.Unmarshal(line, &obj); err != nil {
+		return time.Time{}, false
+	}
+	for _, key := range []string{"ts", "time", "timestamp", "@timestamp"} {
+		raw, ok := obj[key]
+		if !ok {
+			continue
+		}
+		s, ok := raw.(string)
+		if !ok {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339Nano, s)
+		if err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
 }
 
 func writeErr(w http.ResponseWriter, status int, msg string) {

--- a/internal/codexremote/client/client.go
+++ b/internal/codexremote/client/client.go
@@ -44,6 +44,15 @@ type ExecStartResponse struct {
 	Status string `json:"status"`
 }
 
+type ExecLogsOptions struct {
+	Stream    string
+	TailBytes int64
+	TailLines int
+	Since     string
+	Until     string
+	Format    string
+}
+
 func (c *Client) Health(ctx context.Context) (map[string]any, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", c.BaseURL+"/health", nil)
 	if err != nil {
@@ -134,17 +143,26 @@ func (c *Client) ExecCancel(ctx context.Context, execID string) (json.RawMessage
 	return json.RawMessage(b), nil
 }
 
-func (c *Client) ExecLogs(ctx context.Context, execID string, stream string, tail int64, format string, w io.Writer) error {
+func (c *Client) ExecLogs(ctx context.Context, execID string, opts ExecLogsOptions, w io.Writer) error {
 	u := c.BaseURL + "/v1/exec/" + url.PathEscape(execID) + "/logs"
 	q := url.Values{}
-	if stream != "" {
-		q.Set("stream", stream)
+	if opts.Stream != "" {
+		q.Set("stream", opts.Stream)
 	}
-	if tail >= 0 {
-		q.Set("tail", fmt.Sprintf("%d", tail))
+	if opts.TailBytes >= 0 {
+		q.Set("tail", fmt.Sprintf("%d", opts.TailBytes))
 	}
-	if format != "" {
-		q.Set("format", format)
+	if opts.TailLines > 0 {
+		q.Set("tail_lines", fmt.Sprintf("%d", opts.TailLines))
+	}
+	if opts.Since != "" {
+		q.Set("since", opts.Since)
+	}
+	if opts.Until != "" {
+		q.Set("until", opts.Until)
+	}
+	if opts.Format != "" {
+		q.Set("format", opts.Format)
 	}
 	if strings.Contains(u, "?") {
 		u += "&" + q.Encode()


### PR DESCRIPTION
Implements PR-5 from the agreed plan.

- Adds --tail-lines, --since, --until on CLI
- Extends client/daemon logs API with tail_lines/since/until
- Uses line-first then time-window filtering and keeps --tail compatibility