### PR TITLE
PR6: add structured artifacts in exec result

### DIFF
--- a/internal/codexd/service/service.go
+++ b/internal/codexd/service/service.go
@@ -90,6 +90,8 @@ type execMeta struct {
 	FinishedAt string            `json:"finished_at,omitempty"`
 	ExitCode   *int              `json:"exit_code,omitempty"`
 	Error      string            `json:"error,omitempty"`
+	Artifacts  json.RawMessage   `json:"artifacts,omitempty"`
+	Warn       string            `json:"warning,omitempty"`
 }
 
 func (s *Service) handleExecStart(w http.ResponseWriter, r *http.Request) {
@@ -232,6 +234,12 @@ func (s *Service) runExec(execDir string, req execRequest, meta execMeta) {
 	meta.ExitCode = &exitCode
 	if err != nil {
 		meta.Error = err.Error()
+	}
+	if artifacts, warn := collectArtifacts(execDir, cwd); len(artifacts) > 0 {
+		meta.Artifacts = artifacts
+		meta.Warn = warn
+	} else if warn != "" {
+		meta.Warn = warn
 	}
 	_ = writeMeta(execDir, meta)
 	_ = writeExitCode(execDir, exitCode)
@@ -638,6 +646,39 @@ func extractLogTime(line []byte) (time.Time, bool) {
 		}
 	}
 	return time.Time{}, false
+}
+
+func collectArtifacts(execDir, cwd string) (json.RawMessage, string) {
+	candidates := []string{
+		filepath.Join(cwd, ".codex", "artifacts.json"),
+		filepath.Join(execDir, "artifacts.json"),
+	}
+	for _, p := range candidates {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		if !json.Valid(b) {
+			return nil, "artifacts.json is not valid JSON"
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(b, &obj); err != nil {
+			return nil, "artifacts.json decode failed"
+		}
+		arts, ok := obj["artifacts"].([]any)
+		if !ok {
+			return nil, "artifacts.json missing artifacts array"
+		}
+		if len(arts) == 0 {
+			return nil, ""
+		}
+		out, err := json.Marshal(arts)
+		if err != nil {
+			return nil, "artifacts.json marshal failed"
+		}
+		return json.RawMessage(out), ""
+	}
+	return nil, ""
 }
 
 func writeErr(w http.ResponseWriter, status int, msg string) {

--- a/internal/codexd/service/service_test.go
+++ b/internal/codexd/service/service_test.go
@@ -137,9 +137,41 @@ func TestExecLogsTailLinesAndTimeFilter(t *testing.T) {
 	}
 }
 
+func TestExecCollectArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	cfg.DataDir = dir
+	cfg.AllowedCwdRoots = []string{dir}
+	svc := service.New(cfg)
+	h := svc.Handler()
+
+	work := filepath.Join(dir, "work")
+	if err := os.MkdirAll(filepath.Join(work, ".codex"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cmd := `cat > .codex/artifacts.json <<'JSON'
+{"version":"1","artifacts":[{"name":"report","type":"file","path":"report.md"}]}
+JSON
+echo done`
+	execID := startExecWithBody(t, h, map[string]any{
+		"cmd": cmd,
+		"cwd": work,
+	})
+	meta := waitFinished(t, h, execID, 5*time.Second)
+	arts, ok := meta["artifacts"].([]any)
+	if !ok || len(arts) != 1 {
+		t.Fatalf("expected one artifact, got %#v", meta["artifacts"])
+	}
+}
+
 func startExec(t *testing.T, h http.Handler, cmd string) string {
 	t.Helper()
 	reqBody := map[string]any{"cmd": cmd}
+	return startExecWithBody(t, h, reqBody)
+}
+
+func startExecWithBody(t *testing.T, h http.Handler, reqBody map[string]any) string {
+	t.Helper()
 	b, _ := json.Marshal(reqBody)
 	resp := do(t, h, "POST", "/v1/exec", b)
 	var out map[string]any


### PR DESCRIPTION
Implements PR-6 from the agreed plan.

- Collects artifacts.json from conventional paths
- Attaches parsed artifacts to exec result metadata
- Keeps non-blocking behavior with warning on invalid artifact payload