### PR TITLE
PR7: align docs and skill contracts with new workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,17 @@ Config example: `examples/codex-remote-config.yaml`.
 ```bash
 ./codex-remote exec start  --machine gpu1 --cmd "nvidia-smi"
 ./codex-remote exec result --machine gpu1 --id <exec_id>
-./codex-remote exec logs   --machine gpu1 --id <exec_id> --stream stdout --tail 2000
+./codex-remote exec logs   --machine gpu1 --id <exec_id> --stream stdout --tail-lines 200
+./codex-remote exec watch  --machine gpu1 --id <exec_id> --stream both --poll 1s
+./codex-remote exec doctor --machine gpu1 --json
 ./codex-remote exec cancel --machine gpu1 --id <exec_id>
+```
+
+### Native file sync
+
+```bash
+./codex-remote sync push --machine gpu1 --src ./local-dir/ --dst ~/remote-dir/ --exclude .git --exclude node_modules
+./codex-remote sync pull --machine gpu1 --src ~/remote-dir/ --dst ./local-dir/
 ```
 
 ### Direct tunnel rollout (machine config)

--- a/skills/codex-remote-orchestrator/SKILL.md
+++ b/skills/codex-remote-orchestrator/SKILL.md
@@ -12,7 +12,7 @@ Run the full remote execution chain through one skill.
 1. Validate machine readiness.
 2. Submit command and capture `exec_id`.
 3. Query result status.
-4. Fetch logs on demand.
+4. Watch/log retrieval.
 5. Troubleshoot automatically on errors.
 
 ## Step 1: Machine Readiness
@@ -61,19 +61,37 @@ Interpret:
 
 ## Step 4: Logs Query
 
-Stdout:
+Preferred unified watch:
 
 ```bash
-codex-remote exec logs --machine "$MACHINE" --id "$EXEC_ID" --stream stdout --tail 2000
+codex-remote exec watch --machine "$MACHINE" --id "$EXEC_ID" --stream both --poll 1s
+```
+
+Or explicit logs query (line-safe):
+
+```bash
+codex-remote exec logs --machine "$MACHINE" --id "$EXEC_ID" --stream stdout --tail-lines 200
 ```
 
 Stderr:
 
 ```bash
-codex-remote exec logs --machine "$MACHINE" --id "$EXEC_ID" --stream stderr --tail 2000
+codex-remote exec logs --machine "$MACHINE" --id "$EXEC_ID" --stream stderr --tail-lines 200
 ```
 
 Logs are JSONL. Parse line-by-line.
+
+Time window filters:
+
+```bash
+codex-remote exec logs --machine "$MACHINE" --id "$EXEC_ID" --stream stdout --tail-lines 500 --since 10m
+```
+
+Preflight:
+
+```bash
+codex-remote exec doctor --machine "$MACHINE" --json
+```
 
 ## Step 5: Troubleshooting Triggers
 
@@ -101,4 +119,3 @@ When interacting with user or agent caller, keep this structure:
 4. `exit_code` (if finished)
 5. optional `stdout_tail` / `stderr_tail`
 6. next action (`wait`, `done`, or `fix-config`)
-

--- a/skills/codex-remote-result/SKILL.md
+++ b/skills/codex-remote-result/SKILL.md
@@ -12,7 +12,7 @@ Use this skill after an execution has been submitted and `exec_id` is known.
 - `machine` (required)
 - `exec_id` (required)
 - `stream` (optional: `stdout` or `stderr`, default `stdout`)
-- `tail` (optional, default `2000`)
+- `tail-lines` (optional, default `200`)
 
 ## Status Query
 
@@ -28,13 +28,20 @@ Interpretation:
 ## Logs Query
 
 ```bash
-codex-remote exec logs --machine "$MACHINE" --id "$EXEC_ID" --stream stdout --tail 2000
+codex-remote exec logs --machine "$MACHINE" --id "$EXEC_ID" --stream stdout --tail-lines 200
 ```
 
 Notes:
 
 - Output is JSONL (`{"type":"log","stream":"...","line":"..."}` per line).
 - For stderr, set `--stream stderr`.
+- Optional time windows: `--since 10m --until 1m`.
+
+Unified mode:
+
+```bash
+codex-remote exec watch --machine "$MACHINE" --id "$EXEC_ID" --stream both --poll 1s
+```
 
 ## Cancel
 
@@ -43,4 +50,3 @@ codex-remote exec cancel --machine "$MACHINE" --id "$EXEC_ID"
 ```
 
 Use only when user explicitly asks to stop the command.
-

--- a/skills/codex-remote-result/references/result-contract.md
+++ b/skills/codex-remote-result/references/result-contract.md
@@ -7,14 +7,24 @@
   - `status`: `running` or `finished`
   - `exit_code`: present when finished
   - `error`: optional runtime error detail
+  - `artifacts`: optional structured artifacts array
 
 ## `exec logs`
 
 - Returns NDJSON lines.
 - Read line-by-line; do not assume a JSON array.
+- Supports `tail_lines`, `since`, `until` filters.
+
+## `exec watch`
+
+- Streams logs and ends with one summary event containing:
+  - `exec_id`
+  - `status`
+  - `exit_code`
+  - `duration_ms`
+  - `stdout_log_path` / `stderr_log_path`
 
 ## Operator policy
 
 - Always preserve `exec_id` in responses.
 - Do not fabricate completion; rely on returned status and exit code.
-


### PR DESCRIPTION
Implements PR-7 from the agreed plan.

- Updates README command examples
- Updates orchestrator/result skills and result contract docs
- Aligns docs with sync/doctor/watch/log filters/artifacts behavior