### PR TITLE
fix(release): include codexd checksums for updater

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           set -euo pipefail
           cd dist
-          find . -type f \( -name 'codex-*' -o -name 'codex-*.exe' \) | sort | while read -r f; do
+          find . -type f \( -name 'codex-*' -o -name 'codex-*.exe' -o -name 'codexd' -o -name 'codexd.exe' \) | sort | while read -r f; do
             sha256sum "$f"
           done > SHA256SUMS
 


### PR DESCRIPTION
## Summary
- include codexd/codexd.exe in SHA256SUMS generation
- keep existing codex-remote checksum entries unchanged
- fix updater failure: checksum for ./linux-amd64/codexd not found in SHA256SUMS

## Validation
- reviewed release workflow checksum file pattern and release asset naming
