### PR TITLE
fix(sync): stream rsync output and improve probe failures

### DIFF
--- a/cmd/codex-remote/sync_test.go
+++ b/cmd/codex-remote/sync_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTailBufferKeepsLastBytes(t *testing.T) {
+	tb := newTailBuffer(5)
+	if _, err := tb.Write([]byte("abc")); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if _, err := tb.Write([]byte("defg")); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if got := tb.String(); got != "cdefg" {
+		t.Fatalf("tail = %q, want %q", got, "cdefg")
+	}
+}
+
+func TestTailBufferHandlesLargeChunk(t *testing.T) {
+	tb := newTailBuffer(4)
+	if _, err := tb.Write([]byte("123456")); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if got := tb.String(); got != "3456" {
+		t.Fatalf("tail = %q, want %q", got, "3456")
+	}
+}
+
+func TestTailBufferZeroLimit(t *testing.T) {
+	tb := newTailBuffer(0)
+	if _, err := tb.Write([]byte(strings.Repeat("x", 10))); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if got := tb.String(); got != "" {
+		t.Fatalf("tail = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary
- stream rsync stdout/stderr live during sync so long-running transfers no longer appear stuck
- keep only bounded stdout/stderr tails (128KB each) in JSON output to avoid unbounded memory use
- improve remote rsync probe failure message to surface actual SSH/probe error instead of always reporting missing rsync
- add unit tests for tail buffer truncation behavior

## Repro and verification
- reproduced failure with installed binary: `codex-remote sync push --machine ziplab-5090 ...` reported `sync failed: remote rsync is not installed`
- confirmed remote machine has rsync via `codex-remote machine ssh --machine ziplab-5090 --cmd "command -v rsync"`
- validated patched binary with end-to-end smoke test on ziplab-5090:
  - sync push local temp dir -> /tmp remote dir
  - sync pull remote dir -> local temp dir
  - file content hash matches after round trip
- tests: `go test ./cmd/codex-remote`, `go test ./...`