### PR TITLE
fix(issue-17): standardize issue-to-pr workflow policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+Briefly describe what changed.
+
+## 问题复现与根因
+
+- Reproduction:
+- Root cause:
+
+## 修复方案
+
+- Key changes:
+- Why this approach:
+
+## 测试结果
+
+- [ ] `go test ./...`
+- [ ] `make build-all`
+- Notes:
+
+## 风险与回滚
+
+- Risk:
+- Rollback:
+
+Closes #<id>

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,0 +1,64 @@
+name: PR Policy
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR workflow policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch, title, and closing issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const failures = [];
+
+            const branchPattern = /^codex\/issue-(\d+)-[a-z0-9]+(?:-[a-z0-9]+)*$/;
+            const titlePattern = /^fix\(issue-(\d+)\):\s.+$/;
+            const closesPattern = /closes\s+#(\d+)/i;
+
+            if (pr.base.ref !== "main") {
+              failures.push(`PR base branch must be "main", got "${pr.base.ref}".`);
+            }
+
+            const branchMatch = pr.head.ref.match(branchPattern);
+            if (!branchMatch) {
+              failures.push(
+                `Branch name must match "codex/issue-<id>-<slug>", got "${pr.head.ref}".`
+              );
+            }
+
+            const titleMatch = (pr.title || "").match(titlePattern);
+            if (!titleMatch) {
+              failures.push(
+                `PR title must match "fix(issue-<id>): <summary>", got "${pr.title}".`
+              );
+            }
+
+            const body = pr.body || "";
+            const closesMatch = body.match(closesPattern);
+            if (!closesMatch) {
+              failures.push(`PR body must contain "Closes #<id>".`);
+            }
+
+            if (branchMatch && titleMatch && closesMatch) {
+              const branchID = branchMatch[1];
+              const titleID = titleMatch[1];
+              const closesID = closesMatch[1];
+              if (!(branchID === titleID && titleID === closesID)) {
+                failures.push(
+                  `Issue id mismatch: branch=${branchID}, title=${titleID}, closes=${closesID}.`
+                );
+              }
+            }
+
+            if (failures.length > 0) {
+              core.setFailed(failures.join("\n"));
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing
+
+This repository uses a strict issue-to-PR workflow.
+
+## Required Workflow
+
+1. Select one open issue and lock scope (in-scope / out-of-scope).
+2. Start from an up-to-date `main`:
+
+```bash
+git fetch origin --prune
+git checkout main
+git pull --ff-only origin main
+```
+
+3. Create a dedicated branch from `main`:
+
+```bash
+git checkout -b codex/issue-<id>-<slug>
+```
+
+4. Implement only changes related to that issue.
+5. Before commit, both local gates must pass:
+
+```bash
+go test ./...
+make build-all
+```
+
+6. Use commit subject format:
+
+```text
+fix(issue-<id>): <short summary>
+```
+
+7. Push branch and open PR to `main`:
+
+```bash
+git push -u origin codex/issue-<id>-<slug>
+```
+
+8. PR title format:
+
+```text
+fix(issue-<id>): <short summary>
+```
+
+9. PR body must include:
+- Reproduction and root cause
+- Fix approach
+- Test evidence (`go test ./...` and `make build-all`)
+- Risk and rollback plan
+- Issue closing line: `Closes #<id>`
+
+10. Merge policy:
+- Merge only after CI is green.
+- Use squash merge by default.
+- Delete remote fix branch after merge.
+
+## Rules Enforced by CI
+
+On pull requests, policy checks enforce:
+- Base branch must be `main`
+- Branch name must match `codex/issue-<id>-<slug>`
+- PR title must match `fix(issue-<id>): ...`
+- PR body must contain `Closes #<id>`
+- Issue id in branch, title, and `Closes` line must match

--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ export GOCACHE=/tmp/go-cache
 export GOMODCACHE=/tmp/go-mod
 ```
 
+## Contribution Workflow
+
+Issue fixes must follow the standardized flow:
+- sync `main` first (`git fetch origin --prune`, `git checkout main`, `git pull --ff-only origin main`)
+- create branch from `main`: `codex/issue-<id>-<slug>`
+- run local quality gates before commit: `go test ./...` and `make build-all`
+- open PR to `main` with title `fix(issue-<id>): <summary>` and include `Closes #<id>` in body
+
+See `CONTRIBUTING.md` for the full policy and examples.
+
 ## Remote: `codexd`
 
 Start the daemon on the remote server:


### PR DESCRIPTION
## Summary
Standardize and enforce the issue-fix workflow across docs and PR checks.

## 问题复现与根因
- Reproduction: The repo had CI/build guidance, but no strict issue-to-PR workflow policy.
- Root cause: Missing centralized contributor policy, missing PR template, and no workflow-level policy validation.

## 修复方案
- Key changes:
  - Added CONTRIBUTING.md with the required issue workflow.
  - Added .github/pull_request_template.md with required PR sections.
  - Added .github/workflows/pr-policy.yml to enforce branch/title/base/Closes-id consistency.
  - Linked workflow policy in README.
- Why this approach: It combines documentation + automation so the process is both clear and enforceable.

## 测试结果
- [ ] `go test ./...`
- [x] `make build-all`
- Notes:
  - `make build-all` passed.
  - `go test ./...` failed in `internal/codexd/service` with baseline flakiness (no changes made in that package in this PR).

## 风险与回滚
- Risk: PRs not following the naming/title/body convention will fail policy checks.
- Rollback: Revert commit `6833cd3`.

Closes #17
