### PR TITLE
Support addr-only machine checks and update health-check skills

### DIFF
--- a/cmd/codex-remote/main_test.go
+++ b/cmd/codex-remote/main_test.go
@@ -17,17 +17,18 @@ func TestMachineListSummary(t *testing.T) {
 		{Name: "a", SSHOK: true, DaemonOK: true},
 		{Name: "b", SSHOK: true, DaemonOK: false},
 		{Name: "c", SSHOK: false, DaemonOK: false},
+		{Name: "d", SSHOK: false, DaemonOK: true},
 	}
 
 	s := machineListSummary(statuses)
-	if s.Total != 3 {
-		t.Fatalf("Total = %d, want 3", s.Total)
+	if s.Total != 4 {
+		t.Fatalf("Total = %d, want 4", s.Total)
 	}
 	if s.SSHOK != 2 {
 		t.Fatalf("SSHOK = %d, want 2", s.SSHOK)
 	}
-	if s.DaemonOK != 1 {
-		t.Fatalf("DaemonOK = %d, want 1", s.DaemonOK)
+	if s.DaemonOK != 2 {
+		t.Fatalf("DaemonOK = %d, want 2", s.DaemonOK)
 	}
 	if s.Failed != 2 {
 		t.Fatalf("Failed = %d, want 2", s.Failed)

--- a/internal/codexremote/dashboard/dashboard.go
+++ b/internal/codexremote/dashboard/dashboard.go
@@ -61,7 +61,7 @@ var indexTmpl = template.Must(template.New("index").Parse(`
   </head>
   <body>
     <h2>Machines</h2>
-    <p>Checks: SSH reachable + daemon <code>/health</code> on <code>127.0.0.1:&lt;port&gt;</code>.</p>
+	    <p>Checks: SSH reachable or direct <code>addr</code>, plus daemon <code>/health</code>.</p>
     <table>
       <thead>
         <tr><th>Name</th><th>SSH</th><th>Daemon</th><th>Latency</th><th>Last Check</th><th>Actions</th></tr>

--- a/internal/codexremote/machcheck/machcheck.go
+++ b/internal/codexremote/machcheck/machcheck.go
@@ -23,6 +23,17 @@ type Status struct {
 	DaemonAddr string `json:"daemon_addr,omitempty"`
 }
 
+var addrHealthCheck = func(ctx context.Context, addr string) bool {
+	req, _ := http.NewRequestWithContext(ctx, "GET", strings.TrimRight(addr, "/")+"/health", nil)
+	hc := &http.Client{Timeout: 2 * time.Second}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return false
+	}
+	_ = resp.Body.Close()
+	return resp.StatusCode/100 == 2
+}
+
 func Check(ctx context.Context, m config.Machine) Status {
 	start := time.Now()
 	st := Status{
@@ -31,46 +42,52 @@ func Check(ctx context.Context, m config.Machine) Status {
 		CheckedAt:  time.Now().UTC().Format(time.RFC3339Nano),
 	}
 
-	if m.SSH == "" {
-		st.Error = "machine.ssh is required for check"
+	hasSSH := strings.TrimSpace(m.SSH) != ""
+	hasAddr := strings.TrimSpace(m.Addr) != ""
+	if !hasSSH && !hasAddr {
+		st.Error = "machine.ssh or machine.addr is required for check"
 		st.LatencyMS = time.Since(start).Milliseconds()
 		return st
 	}
 
-	res, err := sshutil.RunSSH(ctx, m.SSH, "echo ok")
-	if err != nil || strings.TrimSpace(res.Stdout) != "ok" {
-		st.Error = strings.TrimSpace(res.Stderr)
-		if st.Error == "" {
-			st.Error = "ssh not reachable"
-		}
-		st.LatencyMS = time.Since(start).Milliseconds()
-		return st
-	}
-	st.SSHOK = true
-
-	healthCmd := fmt.Sprintf("curl -fsS http://127.0.0.1:%d/health", m.DaemonPort)
-	res2, err := sshutil.RunSSH(ctx, m.SSH, healthCmd)
-	if err == nil {
-		var tmp map[string]any
-		if json.Unmarshal([]byte(res2.Stdout), &tmp) == nil {
-			st.DaemonOK = true
-		}
-	}
-	if !st.DaemonOK && m.Addr != "" {
-		// Optional: if addr is configured (e.g. VSCode forward already), check directly too.
-		req, _ := http.NewRequestWithContext(ctx, "GET", strings.TrimRight(m.Addr, "/")+"/health", nil)
-		hc := &http.Client{Timeout: 2 * time.Second}
-		if resp, err := hc.Do(req); err == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode/100 == 2 {
-				st.DaemonOK = true
-				st.DaemonAddr = m.Addr
+	sshErr := ""
+	if hasSSH {
+		res, err := sshutil.RunSSH(ctx, m.SSH, "echo ok")
+		if err == nil && strings.TrimSpace(res.Stdout) == "ok" {
+			st.SSHOK = true
+		} else {
+			sshErr = strings.TrimSpace(res.Stderr)
+			if sshErr == "" {
+				sshErr = "ssh not reachable"
 			}
 		}
 	}
 
-	if st.SSHOK && !st.DaemonOK {
-		st.Error = "daemon not healthy"
+	if st.SSHOK {
+		healthCmd := fmt.Sprintf("curl -fsS http://127.0.0.1:%d/health", m.DaemonPort)
+		res2, err := sshutil.RunSSH(ctx, m.SSH, healthCmd)
+		if err == nil {
+			var tmp map[string]any
+			if json.Unmarshal([]byte(res2.Stdout), &tmp) == nil {
+				st.DaemonOK = true
+			}
+		}
+	}
+
+	if !st.DaemonOK && hasAddr {
+		// Optional: if addr is configured (e.g. VSCode forward already), check directly too.
+		if addrHealthCheck(ctx, m.Addr) {
+			st.DaemonOK = true
+			st.DaemonAddr = m.Addr
+		}
+	}
+
+	if !st.DaemonOK {
+		if sshErr != "" {
+			st.Error = sshErr
+		} else {
+			st.Error = "daemon not healthy"
+		}
 	}
 	st.LatencyMS = time.Since(start).Milliseconds()
 	return st

--- a/internal/codexremote/machcheck/machcheck_test.go
+++ b/internal/codexremote/machcheck/machcheck_test.go
@@ -1,0 +1,46 @@
+package machcheck
+
+import (
+	"context"
+	"testing"
+
+	"codex-runner/internal/codexremote/config"
+)
+
+func TestCheckAddrOnlyHealthy(t *testing.T) {
+	orig := addrHealthCheck
+	t.Cleanup(func() { addrHealthCheck = orig })
+	addrHealthCheck = func(ctx context.Context, addr string) bool { return true }
+
+	st := Check(context.Background(), config.Machine{
+		Name:       "addr-only",
+		Addr:       "http://127.0.0.1:7337",
+		DaemonPort: 7337,
+	})
+
+	if st.DaemonOK != true {
+		t.Fatalf("DaemonOK = %v, want true", st.DaemonOK)
+	}
+	if st.SSHOK != false {
+		t.Fatalf("SSHOK = %v, want false", st.SSHOK)
+	}
+	if st.Error != "" {
+		t.Fatalf("Error = %q, want empty", st.Error)
+	}
+	if st.DaemonAddr != "http://127.0.0.1:7337" {
+		t.Fatalf("DaemonAddr = %q, want %q", st.DaemonAddr, "http://127.0.0.1:7337")
+	}
+}
+
+func TestCheckRequiresSSHOrAddr(t *testing.T) {
+	st := Check(context.Background(), config.Machine{Name: "invalid", DaemonPort: 7337})
+	if st.DaemonOK {
+		t.Fatalf("DaemonOK = true, want false")
+	}
+	if st.SSHOK {
+		t.Fatalf("SSHOK = true, want false")
+	}
+	if st.Error != "machine.ssh or machine.addr is required for check" {
+		t.Fatalf("Error = %q", st.Error)
+	}
+}

--- a/skills/codex-remote-machine/SKILL.md
+++ b/skills/codex-remote-machine/SKILL.md
@@ -19,9 +19,9 @@ codex-remote machine check --machine "$MACHINE"
 
 Interpretation:
 
-- `ssh_ok=true` and `daemon_ok=true`: ready for execution.
-- `ssh_ok=false`: SSH path is broken or host is unreachable.
-- `ssh_ok=true` but `daemon_ok=false`: remote daemon is down or unhealthy.
+- `daemon_ok=true`: ready for execution (this includes addr-only machines with `ssh_ok=false`).
+- `daemon_ok=false` and `ssh_ok=true`: remote daemon is down/unhealthy; can try `machine up`.
+- `daemon_ok=false` and `ssh_ok=false`: neither SSH nor direct addr health path is usable.
 
 ## Start Remote Daemon
 
@@ -29,7 +29,7 @@ Interpretation:
 codex-remote machine up --machine "$MACHINE"
 ```
 
-Then run check again.
+Only run `machine up` when SSH is configured/reachable. For addr-only machines, fix local port-forward or `addr` first, then run check again.
 
 ## Dashboard
 
@@ -38,4 +38,3 @@ codex-remote dashboard --listen 127.0.0.1:8787
 ```
 
 Use for visual fleet monitoring and quick check/up operations.
-

--- a/skills/codex-remote-machine/references/health-readings.md
+++ b/skills/codex-remote-machine/references/health-readings.md
@@ -5,12 +5,13 @@
 - `name`
 - `ssh_ok`
 - `daemon_ok`
+- `daemon_addr` (present when direct addr health check is used)
 - `latency_ms`
 - `error`
 - `checked_at`
 
 Recommended reaction:
 
-- `ssh_ok=false`: fix SSH target/keys/network.
-- `daemon_ok=false`: run `machine up`, then re-check.
-
+- `daemon_ok=true`: machine is usable, even if `ssh_ok=false` (addr-only mode).
+- `daemon_ok=false` and `ssh_ok=true`: run `machine up`, then re-check.
+- `daemon_ok=false` and `ssh_ok=false`: fix direct `addr` / local forwarding first; if SSH mode is expected, also fix SSH.

--- a/skills/codex-remote-machine/scripts/check_and_up.sh
+++ b/skills/codex-remote-machine/scripts/check_and_up.sh
@@ -10,8 +10,7 @@ machine="$1"
 check="$(codex-remote machine check --machine "$machine")"
 echo "$check"
 
-if echo "$check" | rg -q '"daemon_ok"\s*:\s*false'; then
+if echo "$check" | rg -q '"daemon_ok"\s*:\s*false' && echo "$check" | rg -q '"ssh_ok"\s*:\s*true'; then
   codex-remote machine up --machine "$machine"
   codex-remote machine check --machine "$machine"
 fi
-

--- a/skills/codex-remote-orchestrator/SKILL.md
+++ b/skills/codex-remote-orchestrator/SKILL.md
@@ -30,7 +30,7 @@ codex-remote machine up --machine "$MACHINE"
 codex-remote machine check --machine "$MACHINE"
 ```
 
-Abort only if SSH remains unreachable.
+Only do this when `ssh_ok=true`. If `ssh_ok=false`, treat it as addr-only/direct-path troubleshooting and verify `addr`/port-forward instead of calling `machine up`.
 
 ## Step 2: Choose Mode
 
@@ -130,6 +130,7 @@ codex-remote exec start --machine "$MACHINE" --cmd "hostname"
 When interacting with user or agent caller, keep this structure:
 
 1. `machine` and readiness (`ssh_ok`, `daemon_ok`)
+   - `daemon_ok=true` is the execution gate (SSH may be false for addr-only machines)
 2. `mode` (`run` or `async`)
 3. `exec_id` (async only)
 4. `status`

--- a/skills/codex-remote-orchestrator/references/playbook.md
+++ b/skills/codex-remote-orchestrator/references/playbook.md
@@ -18,3 +18,4 @@ Decision rules:
 - If long-running, use async and return exec_id first.
 - Mode decision is caller-owned; do not attempt automatic classification inside codex-remote.
 - If status is `finished` and `exit_code != 0`, fetch stderr tail before concluding.
+- In readiness checks, use `daemon_ok` as gate; `ssh_ok=false` can still be valid for addr-only machines.

--- a/skills/codex-remote-orchestrator/scripts/run_chain.sh
+++ b/skills/codex-remote-orchestrator/scripts/run_chain.sh
@@ -15,7 +15,7 @@ echo "# machine check"
 check="$(codex-remote machine check --machine "$machine")"
 echo "$check"
 
-if echo "$check" | rg -q '"daemon_ok"\s*:\s*false'; then
+if echo "$check" | rg -q '"daemon_ok"\s*:\s*false' && echo "$check" | rg -q '"ssh_ok"\s*:\s*true'; then
   echo "# machine up"
   codex-remote machine up --machine "$machine"
   codex-remote machine check --machine "$machine"
@@ -27,4 +27,3 @@ if [[ -n "$project" ]]; then
 else
   codex-remote exec start --machine "$machine" --cmd "$cmd"
 fi
-

--- a/skills/codex-remote-troubleshoot/SKILL.md
+++ b/skills/codex-remote-troubleshoot/SKILL.md
@@ -11,9 +11,10 @@ Use this skill for fast triage when command execution fails.
 
 1. Validate machine profile exists in local config.
 2. Run `machine check`.
-3. Verify local direct addr vs SSH forwarding path.
-4. Retry with a tiny command (`hostname`).
-5. Inspect remote daemon logs if available.
+3. Interpret check result: `daemon_ok=true` means runnable (even if `ssh_ok=false` in addr-only mode).
+4. Verify local direct addr vs SSH forwarding path only when `daemon_ok=false`.
+5. Retry with a tiny command (`hostname`).
+6. Inspect remote daemon logs if available.
 
 ## Common Errors And Fixes
 
@@ -33,4 +34,3 @@ codex-remote exec start --machine "$MACHINE" --cmd "hostname"
 ```
 
 If submission succeeds, use result/logs to complete chain.
-

--- a/skills/codex-remote-troubleshoot/references/error-map.md
+++ b/skills/codex-remote-troubleshoot/references/error-map.md
@@ -2,6 +2,6 @@
 
 - `failed to create ssh forward`: SSH target invalid or authentication blocked.
 - `daemon not healthy`: `codexd` process not listening on configured port.
+- `machine.ssh or machine.addr is required for check`: machine profile is missing both connectivity paths.
 - `cwd not allowed`: provided path violates server whitelist constraints.
 - `ref is required when project_id is set`: include `--ref` with `--project`.
-


### PR DESCRIPTION
## Summary
- allow `machine check` to pass for addr-only machines (no SSH) when direct `addr/health` is reachable
- keep SSH-based checks when `ssh` exists, and return clearer error when neither `ssh` nor `addr` is configured
- treat machine list failure state based on daemon availability/error so addr-only healthy machines are not marked failed
- update dashboard health-check description to include direct addr mode
- update codex-remote skills/docs/scripts so health-check guidance and automation logic match addr-only behavior

## Testing
- GOCACHE=/tmp/go-cache GOMODCACHE=/tmp/go-mod go test ./cmd/codex-remote ./internal/codexremote/machcheck